### PR TITLE
Add export placeholder

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -3,6 +3,13 @@ import json
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog, filedialog
 
+from mod_manager_backend import (
+    unpack_smallf,
+    apply_mods_to_temp,
+    repack_smallf,
+    export_smallf_to_game,
+)
+
 # --- Dummy data for demo purposes ---
 GAMES = ['Full Auto (Xbox 360)', 'Full Auto 2: Battlelines (PS3)']
 DEMO_PROFILES = ['Default', 'Debug', 'Modded Physics']
@@ -94,10 +101,31 @@ class FAModManager(tk.Tk):
 
     def set_active_profile(self):
         selected = self.profile_list.curselection()
-        if selected:
-            messagebox.showinfo("Active Profile", f"Set '{self.profile_list.get(selected[0])}' as active.")
-        else:
+        if not selected:
             messagebox.showwarning("Select a Profile", "No profile selected!")
+            return
+
+        selected_game = self.game_var.get()
+        game_root = self.game_paths.get(selected_game, "")
+        if not game_root:
+            messagebox.showerror("Error", "Game folder not set. Please use Settings first.")
+            return
+
+        profile_name = self.profile_list.get(selected[0])
+
+        if "Full Auto 2" in selected_game:
+            game_key = "fa2"
+        else:
+            game_key = "fa"
+
+        try:
+            export_smallf_to_game(game_key, profile_name, game_root)
+            messagebox.showinfo(
+                "Active Profile",
+                f"Exported smallf for '{profile_name}' to game folder as smallf_modified.dat.",
+            )
+        except FileNotFoundError as exc:
+            messagebox.showerror("Error", str(exc))
 
     def rename_profile(self):
         selected = self.profile_list.curselection()
@@ -118,20 +146,33 @@ class FAModManager(tk.Tk):
             messagebox.showwarning("Select a Profile", "No profile selected!")
 
     def merge_mods(self):
-        # Example use of the saved path (replace with real logic as needed)
         selected_game = self.game_var.get()
         game_root = self.game_paths.get(selected_game, "")
         if not game_root:
             messagebox.showerror("Error", "Game folder not set. Please use Settings first.")
             return
 
-        smallf_path = os.path.join(game_root, "PS3_GAME", "USRDIR", "smallf.dat")
-        if not os.path.isfile(smallf_path):
-            messagebox.showerror("Error", "Could not find smallf.dat in your game folder.")
+        profile_sel = self.profile_list.curselection()
+        if not profile_sel:
+            messagebox.showwarning("Select a Profile", "No profile selected!")
             return
+        profile_name = self.profile_list.get(profile_sel[0])
 
-        # Replace with real merge/copy logic
-        messagebox.showinfo("Merge", f"Would now patch/replace:\n{smallf_path}")
+        if "Full Auto 2" in selected_game:
+            game_key = "fa2"
+        else:
+            game_key = "fa"
+
+        try:
+            unpack_smallf(game_key)
+            apply_mods_to_temp(game_key, mods=[])  # Placeholder for real mods
+            repack_smallf(game_key, profile_name)
+            messagebox.showinfo(
+                "Merge",
+                f"Saved new smallf for profile '{profile_name}'. Use Set Active to export."
+            )
+        except Exception as exc:
+            messagebox.showerror("Merge Failed", str(exc))
 
 if __name__ == "__main__":
     app = FAModManager()

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -64,6 +64,28 @@ def repack_smallf(game, mod_name):
     print(f"[OK] Repacked smallf written to: {dest}")
     return dest
 
+# ----------- Export to game folder -----------
+def export_smallf_to_game(game, mod_name, game_root):
+    """Copy the repacked smallf.dat into the given game's PS3 folder.
+
+    The file is renamed to ``smallf_modified.dat`` so existing game files are
+    left untouched. ``game`` should be either ``'fa'`` or ``'fa2'``.
+    """
+    if game == "fa2":
+        finished_subdir = os.path.join(FINISHED_DIR, "fa2", mod_name)
+    else:
+        finished_subdir = os.path.join(FINISHED_DIR, "fa", mod_name)
+
+    src = os.path.join(finished_subdir, "smallf.dat")
+    if not os.path.isfile(src):
+        raise FileNotFoundError(f"Repacked file not found: {src}")
+
+    dest_dir = os.path.join(game_root, "PS3_GAME", "USRDIR")
+    os.makedirs(dest_dir, exist_ok=True)
+    dest = os.path.join(dest_dir, "smallf_modified.dat")
+    shutil.copy2(src, dest)
+    print(f"[OK] Exported modified smallf to: {dest}")
+
 # ----------- Patch/merge logic placeholder -----------
 def apply_mods_to_temp(game, mods):
     """
@@ -93,6 +115,18 @@ if __name__ == "__main__":
 
     # 3. Repack
     output_smallf = repack_smallf(selected_game, mod_name)
+
+    # 4. Export to the game folder if configured
+    game_paths = load_game_paths()
+    if selected_game == "fa2":
+        key = "Full Auto 2: Battlelines (PS3)"
+    else:
+        key = "Full Auto (Xbox 360)"
+    game_root = game_paths.get(key)
+    if game_root:
+        export_smallf_to_game(selected_game, mod_name, game_root)
+    else:
+        print("[WARN] Game path not configured; skipping export.")
 
     print("\n[Done] Workflow complete.")
     print(f"You can find your new smallf.dat here:\n  {output_smallf}")


### PR DESCRIPTION
## Summary
- add backend export_smallf_to_game to copy `smallf.dat` into the PS3 game folder as `smallf_modified.dat`
- export repacked file in backend sample workflow using configured game path
- update GUI placeholder to mention `smallf_modified.dat`

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6882363cdcf883218ff4d75957e345a8