### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Full Auto Mod Manager
+
+This project provides a proof of concept for managing and merging mods for **Full Auto** (Xbox 360) and **Full Auto 2: Battlelines** (PS3). It relies on command line tools to unpack and repack `smallf.dat` so that modified files can be exported back to the game.
+
+## Requirements
+
+- Windows operating system. The repo includes Windows executables used to unpack and repack game data:
+  - `smallf/tools/unpack_smallf_win.exe`
+  - `smallf/tools/repack_smallf_win.exe`
+- Python 3 with Tkinter for the GUI (`mod_manager.py`).
+
+## Configuring Game Paths
+
+Game directories are stored in `fa_mod_manager_config.json`. Each key is the game name and the value is the path to the game's root folder. The JSON looks like the following:
+
+```json
+{
+    "Full Auto (Xbox 360)": "C:/Path/To/Full Auto",
+    "Full Auto 2: Battlelines (PS3)": "C:/Path/To/Full Auto 2"
+}
+```
+
+Use the **Settings** button in the GUI to select or update these paths. The backend saves them using `save_game_paths()` and they are loaded on startup via `load_game_paths()`.
+
+## Basic Workflow
+
+1. **Unpack** – `backend.unpack_smallf(game)` copies the original `smallf.dat` and unpacks it using `unpack_smallf_win.exe`.
+2. **Apply Mods** – modify files in the temporary folder (handled by `apply_mods_to_temp`).
+3. **Repack** – `backend.repack_smallf(game, mod_name)` uses `repack_smallf_win.exe` to rebuild `smallf.dat` and places it under `smallf/finished/<game>/<mod_name>/`.
+4. **Export** – `backend.export_smallf_to_game(game, mod_name, game_root)` copies the new file to `PS3_GAME/USRDIR/smallf_modified.dat` in your configured game directory.
+
+This sequence is also demonstrated in the `__main__` section of `mod_manager_backend.py` and forms the foundation of the GUI.


### PR DESCRIPTION
## Summary
- add README detailing Windows requirements
- document how to configure `fa_mod_manager_config.json`
- explain the unpack → mod → repack → export workflow

## Testing
- `python3 -m py_compile mod_manager.py mod_manager_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_68825be2619483218310cd2e0689a080