### PR TITLE
Add config template and update loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+fa_mod_manager_config.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,10 @@ A desktop GUI tool for managing, merging, and applying mods to Full Auto (Xbox 3
 - **`mod_manager_backend.py`**  
   Handles file operations, merging logic, and low-level mod management.
 
-- **`fa_mod_manager_config.json`**  
-  Stores user/game configuration, such as selected folders or mod profile info.
+- **`fa_mod_manager_config.json`**
+  Generated at runtime from `fa_mod_manager_config.example.json`. Stores user/game configuration, such as selected folders or mod profile info.
+- **`fa_mod_manager_config.example.json`**
+  Template configuration file with empty values used to create `fa_mod_manager_config.json` if it does not exist.
 
 - **`smallf/`**  
   Directory for base data files and/or example mod data.

--- a/fa_mod_manager_config.example.json
+++ b/fa_mod_manager_config.example.json
@@ -1,0 +1,4 @@
+{
+  "Full Auto (Xbox 360)": "",
+  "Full Auto 2: Battlelines (PS3)": ""
+}

--- a/fa_mod_manager_config.json
+++ b/fa_mod_manager_config.json
@@ -1,1 +1,0 @@
-{"Full Auto (Xbox 360)": "F:/Games/PS3 Emu/games/Full Auto 2 - Battlelines (Europe) (En,Fr,De,Es,It)", "Full Auto 2: Battlelines (PS3)": "F:/Games/PS3 Emu/games/Full Auto 2 - Battlelines (Europe) (En,Fr,De,Es,It)"}

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -24,6 +24,14 @@ def save_game_paths(game_paths):
         json.dump(game_paths, f)
 
 def load_game_paths():
+    """Return saved game paths, creating an empty config if needed."""
+    if not os.path.isfile(CONFIG_FILE):
+        example = os.path.join(BASE_DIR, "fa_mod_manager_config.example.json")
+        if os.path.isfile(example):
+            shutil.copy2(example, CONFIG_FILE)
+        else:
+            with open(CONFIG_FILE, "w") as f:
+                json.dump({}, f)
     try:
         with open(CONFIG_FILE, "r") as f:
             return json.load(f)


### PR DESCRIPTION
## Summary
- remove user-specific `fa_mod_manager_config.json` from the repo and ignore it
- provide `fa_mod_manager_config.example.json` as template
- create missing config automatically in `load_game_paths`
- document the new template

## Testing
- `python -m py_compile mod_manager.py mod_manager_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_68825a3d20b483218d4d70f7ae0a3748