### PR TITLE
Ensure repack_smallf uses temp directory

### DIFF
--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -75,7 +75,9 @@ def repack_smallf(game, mod_name):
     else:
         temp_dir = TEMP_FA_DIR
         finished_subdir = os.path.join(FINISHED_DIR, "fa", mod_name)
-    subprocess.check_call([exe, temp_dir])
+    # Run the repacker inside the temp directory so its output is generated
+    # relative to that folder, regardless of where this function is called
+    subprocess.check_call([exe, '.'], cwd=temp_dir)
     # The repacker writes <temp_dir>_repack.dat next to the temp folder
     # but some versions may create smallf_repack.dat in the folder instead.
     # Support both to avoid FileNotFoundError.


### PR DESCRIPTION
## Summary
- run the repack tool with the temp folder as cwd
- keep support for `<temp>_repack.dat` and `smallf_repack.dat` outputs

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68825bdcccc4832195df2d928cf66b9a