### PR TITLE
Improve mod profile workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Use the **Settings** button in the GUI to select or update these paths. The back
 4. **Export** – `backend.export_smallf_to_game(game, mod_name, game_root)` copies the new file to `PS3_GAME/USRDIR/smallf_modified.dat` in your configured game directory.
 
 This sequence is also demonstrated in the `__main__` section of `mod_manager_backend.py` and forms the foundation of the GUI.
+
+## Adding Mods
+
+Mods can be added to the list either by dragging `.txt` files onto the mod list
+box or by clicking the **Add Files** button which opens your system's file
+picker. When no mods are loaded, the list shows a helpful "Drag mods here" hint.

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -58,9 +58,24 @@ class FAModManager(TkinterDnD.Tk):
         mods_frame.pack(side='left', fill='both', padx=10, expand=True)
         self.mods_list = tk.Listbox(mods_frame, height=10, selectmode='extended')
         self.mods_list.pack(padx=5, pady=5, fill='both', expand=True)
+        # placeholder label shown when no mods are listed
+        self.mods_placeholder = tk.Label(
+            self.mods_list, text='Drag mods here or use "Add Files"',
+            foreground='gray'
+        )
+        self.mods_placeholder.place(relx=0.5, rely=0.5, anchor='center')
         # Enable drag-and-drop of txt files into the listbox
         self.mods_list.drop_target_register(DND_FILES)
         self.mods_list.dnd_bind('<<Drop>>', self.on_file_drop)
+
+        def update_placeholder(event=None):
+            if self.mods_list.size() == 0:
+                self.mods_placeholder.place(relx=0.5, rely=0.5, anchor='center')
+            else:
+                self.mods_placeholder.place_forget()
+
+        self.update_mod_placeholder = update_placeholder
+        self.update_mod_placeholder()
 
         btn_frame = tk.Frame(mods_frame)
         btn_frame.pack(pady=4)
@@ -68,6 +83,7 @@ class FAModManager(TkinterDnD.Tk):
         tk.Button(btn_frame, text='Down', width=6, command=self.move_down).pack(side='left', padx=2)
         tk.Button(btn_frame, text='Remove', width=8, command=self.remove_selected_mods).pack(side='left', padx=2)
         tk.Button(btn_frame, text='Clear', width=6, command=self.clear_mods).pack(side='left', padx=2)
+        tk.Button(btn_frame, text='Add Files', command=self.add_files).pack(side='left', padx=2)
         tk.Button(mods_frame, text='Merge', command=self.merge_mods).pack(pady=4, fill='x')
 
     def open_settings(self):
@@ -145,6 +161,19 @@ class FAModManager(TkinterDnD.Tk):
             if os.path.isfile(path) and path.lower().endswith('.txt'):
                 self.mods_list.insert('end', os.path.basename(path))
                 self.mod_files.append(path)
+        self.update_mod_placeholder()
+
+    def add_files(self):
+        paths = filedialog.askopenfilenames(
+            title='Select Mod Files',
+            filetypes=[('Text Files', '*.txt'), ('All Files', '*.*')]
+        )
+        for path in paths:
+            if os.path.isfile(path) and path.lower().endswith('.txt'):
+                self.mods_list.insert('end', os.path.basename(path))
+                self.mod_files.append(path)
+        if paths:
+            self.update_mod_placeholder()
 
     def remove_selected_mods(self):
         selection = list(self.mods_list.curselection())
@@ -153,10 +182,12 @@ class FAModManager(TkinterDnD.Tk):
         for index in reversed(selection):
             self.mods_list.delete(index)
             del self.mod_files[index]
+        self.update_mod_placeholder()
 
     def clear_mods(self):
         self.mods_list.delete(0, 'end')
         self.mod_files.clear()
+        self.update_mod_placeholder()
 
     def move_up(self):
         selection = self.mods_list.curselection()
@@ -203,9 +234,8 @@ class FAModManager(TkinterDnD.Tk):
             backend.apply_mods_to_temp(game_key, mods=mod_paths)
             out_path = backend.repack_smallf(game_key, merge_name)
             self.profile_smallfs[merge_name] = (game_key, out_path)
-            # Add the newly merged file as a selectable mod
-            self.mods_list.insert('end', merge_name)
-            self.mod_files.append(out_path)
+            if merge_name not in self.profile_list.get(0, 'end'):
+                self.profile_list.insert('end', merge_name)
             messagebox.showinfo(
                 "Merge Complete",
                 f"Repacked smallf '{merge_name}' saved to:\n{out_path}"


### PR DESCRIPTION
## Summary
- add placeholder text and `Add Files` button for the drag-and-drop mod list
- save merged smallf.dat files into mod profiles instead of the mod list
- document how to add mods via drag/drop or file picker

## Testing
- `python3 -m py_compile mod_manager.py mod_manager_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_6882683e16188321b39573ec485160e4