### PR TITLE
Improve mod profile handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,12 @@ This sequence is also demonstrated in the `__main__` section of `mod_manager_bac
 ## Adding Mods
 
 Mods can be added to the list either by dragging `.txt` files onto the mod list
-box or by clicking the **Add Files** button which opens your system's file
-picker. When no mods are loaded, the list shows a helpful "Drag mods here" hint.
+or by clicking the **Add Files** button which opens your system's file picker.
+Each mod entry now has a checkbox allowing you to enable or disable it for the
+next merge. When no mods are loaded, the list shows a helpful "Drag mods here" hint.
+
+### Importing Mod Profiles
+
+Existing `smallf.dat` files can be imported as mod profiles using the **Import
+Profile** button. Choose a folder containing a `smallf.dat` and it will appear
+in the profile list using the folder name.

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -7,7 +7,7 @@ import mod_manager_backend as backend
 
 # --- Dummy data for demo purposes ---
 GAMES = ['Full Auto (Xbox 360)', 'Full Auto 2: Battlelines (PS3)']
-DEMO_PROFILES = ['Default', 'Debug', 'Modded Physics']
+DEMO_PROFILES = []
 DEMO_MODS = []  # start with an empty mod list
 
 
@@ -20,8 +20,6 @@ class FAModManager(TkinterDnD.Tk):
 
         # Store paths to repacked smallf per profile
         self.profile_smallfs = {}
-        # List of mod file paths corresponding to entries in the listbox
-        self.mod_files = []
 
         # Load or create game paths config
         self.game_paths = {game: "" for game in GAMES}
@@ -44,10 +42,27 @@ class FAModManager(TkinterDnD.Tk):
         profiles_frame = tk.LabelFrame(main_frame, text='Mod Profiles')
         profiles_frame.pack(side='left', fill='y', padx=10, ipadx=8)
         self.profile_list = tk.Listbox(profiles_frame, height=10)
-        for profile in DEMO_PROFILES:
-            self.profile_list.insert('end', profile)
         self.profile_list.pack(padx=5, pady=5)
+        self.profile_placeholder = tk.Label(
+            self.profile_list,
+            text='No mod profiles found, create one or import one',
+            foreground='gray', wraplength=150, justify='center'
+        )
+        self.profile_placeholder.place(relx=0.5, rely=0.5, anchor='center')
+
+        def update_profile_placeholder(event=None):
+            if self.profile_list.size() == 0:
+                self.profile_placeholder.place(relx=0.5, rely=0.5, anchor='center')
+            else:
+                self.profile_placeholder.place_forget()
+
+        self.update_profile_placeholder = update_profile_placeholder
+        for profile in backend.list_existing_profiles():
+            self.profile_list.insert('end', profile)
+            self.profile_smallfs[profile] = (None, os.path.join(backend.FINISHED_DIR, profile, 'smallf.dat'))
+        self.update_profile_placeholder()
         tk.Button(profiles_frame, text='Set Active', command=self.set_active_profile).pack(fill='x', pady=2)
+        tk.Button(profiles_frame, text='Import Profile', command=self.import_profile).pack(fill='x', pady=2)
         b_frame = tk.Frame(profiles_frame)
         b_frame.pack()
         tk.Button(b_frame, text='Rename', command=self.rename_profile).pack(side='left', padx=2)
@@ -56,20 +71,21 @@ class FAModManager(TkinterDnD.Tk):
         # Right: Mod list for selected profile
         mods_frame = tk.LabelFrame(main_frame, text='Mod List')
         mods_frame.pack(side='left', fill='both', padx=10, expand=True)
-        self.mods_list = tk.Listbox(mods_frame, height=10, selectmode='extended')
-        self.mods_list.pack(padx=5, pady=5, fill='both', expand=True)
-        # placeholder label shown when no mods are listed
+        self.mods_container = tk.Frame(mods_frame)
+        self.mods_container.pack(padx=5, pady=5, fill='both', expand=True)
+        self.mod_entries = []
+        self.selected_mod_index = None
+        self.mods_container.drop_target_register(DND_FILES)
+        self.mods_container.dnd_bind('<<Drop>>', self.on_file_drop)
         self.mods_placeholder = tk.Label(
-            self.mods_list, text='Drag mods here or use "Add Files"',
+            self.mods_container,
+            text='Drag mods here or use "Add Files"',
             foreground='gray'
         )
         self.mods_placeholder.place(relx=0.5, rely=0.5, anchor='center')
-        # Enable drag-and-drop of txt files into the listbox
-        self.mods_list.drop_target_register(DND_FILES)
-        self.mods_list.dnd_bind('<<Drop>>', self.on_file_drop)
 
         def update_placeholder(event=None):
-            if self.mods_list.size() == 0:
+            if len(self.mod_entries) == 0:
                 self.mods_placeholder.place(relx=0.5, rely=0.5, anchor='center')
             else:
                 self.mods_placeholder.place_forget()
@@ -124,6 +140,8 @@ class FAModManager(TkinterDnD.Tk):
             return
 
         game_key, _ = info
+        if game_key is None:
+            game_key = "fa2" if "Full Auto 2" in self.game_var.get() else "fa"
         selected_game = self.game_var.get()
         game_root = self.game_paths.get(selected_game, "")
         if not game_root:
@@ -144,24 +162,54 @@ class FAModManager(TkinterDnD.Tk):
             if new_name:
                 self.profile_list.delete(selected[0])
                 self.profile_list.insert(selected[0], new_name)
+                if old_name in self.profile_smallfs:
+                    self.profile_smallfs[new_name] = self.profile_smallfs.pop(old_name)
         else:
             messagebox.showwarning("Select a Profile", "No profile selected!")
 
     def delete_profile(self):
         selected = self.profile_list.curselection()
         if selected:
+            name = self.profile_list.get(selected[0])
             self.profile_list.delete(selected[0])
+            self.profile_smallfs.pop(name, None)
         else:
             messagebox.showwarning("Select a Profile", "No profile selected!")
 
+    def import_profile(self):
+        folder = filedialog.askdirectory(title='Select folder with smallf.dat', mustexist=True)
+        if not folder:
+            return
+        smallf_path = os.path.join(folder, 'smallf.dat')
+        if not os.path.isfile(smallf_path):
+            messagebox.showerror('Error', 'smallf.dat not found in selected folder.')
+            return
+        profile_name = os.path.basename(folder)
+        selected_game = self.game_var.get()
+        game_key = 'fa2' if 'Full Auto 2' in selected_game else 'fa'
+        dest = backend.import_profile(game_key, profile_name, smallf_path)
+        self.profile_smallfs[profile_name] = (game_key, dest)
+        if profile_name not in self.profile_list.get(0, 'end'):
+            self.profile_list.insert('end', profile_name)
+        self.update_profile_placeholder()
+
     # --- Mod list helpers ---
+    def _add_mod(self, path):
+        idx = len(self.mod_entries)
+        var = tk.BooleanVar(value=True)
+        cb = tk.Checkbutton(self.mods_container, text=os.path.basename(path), variable=var, anchor='w')
+        cb.bind('<Button-1>', lambda e, i=idx: self.select_mod(i))
+        cb.pack(anchor='w', fill='x')
+        self.mod_entries.append({'path': path, 'var': var, 'widget': cb})
+        self.update_mod_placeholder()
+
     def on_file_drop(self, event):
         files = self.tk.splitlist(event.data)
         for path in files:
             if os.path.isfile(path) and path.lower().endswith('.txt'):
-                self.mods_list.insert('end', os.path.basename(path))
-                self.mod_files.append(path)
-        self.update_mod_placeholder()
+                self._add_mod(path)
+        if files:
+            self.update_mod_placeholder()
 
     def add_files(self):
         paths = filedialog.askopenfilenames(
@@ -170,54 +218,57 @@ class FAModManager(TkinterDnD.Tk):
         )
         for path in paths:
             if os.path.isfile(path) and path.lower().endswith('.txt'):
-                self.mods_list.insert('end', os.path.basename(path))
-                self.mod_files.append(path)
+                self._add_mod(path)
         if paths:
             self.update_mod_placeholder()
 
+    def select_mod(self, index):
+        if self.selected_mod_index is not None and 0 <= self.selected_mod_index < len(self.mod_entries):
+            self.mod_entries[self.selected_mod_index]['widget'].configure(background=self.mods_container.cget('background'))
+        self.selected_mod_index = index
+        self.mod_entries[index]['widget'].configure(background='lightblue')
+
     def remove_selected_mods(self):
-        selection = list(self.mods_list.curselection())
-        if not selection:
+        idx = self.selected_mod_index
+        if idx is None:
             return
-        for index in reversed(selection):
-            self.mods_list.delete(index)
-            del self.mod_files[index]
+        entry = self.mod_entries.pop(idx)
+        entry['widget'].destroy()
+        self.selected_mod_index = None
         self.update_mod_placeholder()
 
     def clear_mods(self):
-        self.mods_list.delete(0, 'end')
-        self.mod_files.clear()
+        for entry in self.mod_entries:
+            entry['widget'].destroy()
+        self.mod_entries.clear()
+        self.selected_mod_index = None
         self.update_mod_placeholder()
 
+    def refresh_mod_widgets(self):
+        for entry in self.mod_entries:
+            entry['widget'].pack_forget()
+        for entry in self.mod_entries:
+            entry['widget'].pack(anchor='w', fill='x')
+
     def move_up(self):
-        selection = self.mods_list.curselection()
-        if not selection:
+        idx = self.selected_mod_index
+        if idx is None or idx == 0:
             return
-        index = selection[0]
-        if index == 0:
-            return
-        item = self.mods_list.get(index)
-        self.mods_list.delete(index)
-        self.mods_list.insert(index - 1, item)
-        self.mod_files.insert(index - 1, self.mod_files.pop(index))
-        self.mods_list.selection_set(index - 1)
+        self.mod_entries[idx-1], self.mod_entries[idx] = self.mod_entries[idx], self.mod_entries[idx-1]
+        self.selected_mod_index -= 1
+        self.refresh_mod_widgets()
 
     def move_down(self):
-        selection = self.mods_list.curselection()
-        if not selection:
+        idx = self.selected_mod_index
+        if idx is None or idx >= len(self.mod_entries) - 1:
             return
-        index = selection[0]
-        if index == self.mods_list.size() - 1:
-            return
-        item = self.mods_list.get(index)
-        self.mods_list.delete(index)
-        self.mods_list.insert(index + 1, item)
-        self.mod_files.insert(index + 1, self.mod_files.pop(index))
-        self.mods_list.selection_set(index + 1)
+        self.mod_entries[idx+1], self.mod_entries[idx] = self.mod_entries[idx], self.mod_entries[idx+1]
+        self.selected_mod_index += 1
+        self.refresh_mod_widgets()
 
     def merge_mods(self):
-        mod_indices = list(self.mods_list.curselection())
-        if not mod_indices:
+        mod_paths = [e['path'] for e in self.mod_entries if e['var'].get()]
+        if not mod_paths:
             messagebox.showwarning("Select Mods", "No mods selected to merge!")
             return
 
@@ -227,7 +278,6 @@ class FAModManager(TkinterDnD.Tk):
 
         selected_game = self.game_var.get()
         game_key = "fa2" if "Full Auto 2" in selected_game else "fa"
-        mod_paths = [self.mod_files[i] for i in mod_indices]
 
         try:
             backend.unpack_smallf(game_key)
@@ -236,6 +286,7 @@ class FAModManager(TkinterDnD.Tk):
             self.profile_smallfs[merge_name] = (game_key, out_path)
             if merge_name not in self.profile_list.get(0, 'end'):
                 self.profile_list.insert('end', merge_name)
+                self.update_profile_placeholder()
             messagebox.showinfo(
                 "Merge Complete",
                 f"Repacked smallf '{merge_name}' saved to:\n{out_path}"

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -134,6 +134,27 @@ def export_smallf_to_game(game, mod_name, game_root):
     shutil.copy2(src, dest)
     print(f"[OK] Exported modified smallf to: {dest}")
 
+# ----------- Profile management -----------
+def import_profile(game, profile_name, source_smallf):
+    """Import an existing smallf.dat as a mod profile."""
+    finished_subdir = os.path.join(FINISHED_DIR, profile_name)
+    os.makedirs(finished_subdir, exist_ok=True)
+    dest = os.path.join(finished_subdir, "smallf.dat")
+    shutil.copy2(source_smallf, dest)
+    print(f"[OK] Imported profile '{profile_name}' -> {dest}")
+    return dest
+
+
+def list_existing_profiles():
+    """Return names of profiles already present in ``finished``."""
+    if not os.path.isdir(FINISHED_DIR):
+        return []
+    names = []
+    for name in os.listdir(FINISHED_DIR):
+        if os.path.isfile(os.path.join(FINISHED_DIR, name, "smallf.dat")):
+            names.append(name)
+    return names
+
 # ----------- Patch/merge logic placeholder -----------
 def apply_mods_to_temp(game, mods):
     """


### PR DESCRIPTION
## Summary
- add profile import helper and lookup
- switch mod list to use checkboxes
- allow importing existing profiles from smallf.dat
- update README with new usage details

## Testing
- `python -m py_compile mod_manager.py mod_manager_backend.py`
- `python mod_manager.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68826a2cf54c8321914bdeb70d0beed7