### PR TITLE
Fix profile rename persisting

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -159,11 +159,16 @@ class FAModManager(TkinterDnD.Tk):
         if selected:
             old_name = self.profile_list.get(selected[0])
             new_name = simpledialog.askstring("Rename Profile", f"Enter new name for '{old_name}':")
-            if new_name:
+            if new_name and new_name != old_name:
+                try:
+                    new_path = backend.rename_profile(old_name, new_name)
+                except Exception as exc:
+                    messagebox.showerror("Error", f"Failed to rename profile:\n{exc}")
+                    return
                 self.profile_list.delete(selected[0])
                 self.profile_list.insert(selected[0], new_name)
-                if old_name in self.profile_smallfs:
-                    self.profile_smallfs[new_name] = self.profile_smallfs.pop(old_name)
+                game_key, _ = self.profile_smallfs.pop(old_name, (None, None))
+                self.profile_smallfs[new_name] = (game_key, new_path)
         else:
             messagebox.showwarning("Select a Profile", "No profile selected!")
 

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -145,6 +145,18 @@ def import_profile(game, profile_name, source_smallf):
     return dest
 
 
+def rename_profile(old_name, new_name):
+    """Rename a profile folder inside ``finished`` and return new path."""
+    old_dir = os.path.join(FINISHED_DIR, old_name)
+    new_dir = os.path.join(FINISHED_DIR, new_name)
+    if not os.path.isdir(old_dir):
+        raise FileNotFoundError(f"Profile not found: {old_name}")
+    if os.path.isdir(new_dir):
+        raise FileExistsError(f"Profile already exists: {new_name}")
+    os.rename(old_dir, new_dir)
+    return os.path.join(new_dir, "smallf.dat")
+
+
 def list_existing_profiles():
     """Return names of profiles already present in ``finished``."""
     if not os.path.isdir(FINISHED_DIR):


### PR DESCRIPTION
## Summary
- keep renamed profile folders in sync with the GUI
- update profile data after renaming

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68826cee10a08321b7052e0999a46faa