### PR TITLE
Improve mod display and simplify comment output

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -227,7 +227,26 @@ class FAModManager(TkinterDnD.Tk):
     def _add_mod(self, path):
         idx = len(self.mod_entries)
         var = tk.BooleanVar(value=True)
-        cb = tk.Checkbutton(self.mods_container, text=os.path.basename(path), variable=var, anchor='w')
+        try:
+            meta, _ = backend._parse_mod_file(path)
+        except Exception:
+            meta = {}
+
+        name = meta.get('name')
+        author = meta.get('author')
+        desc = meta.get('description')
+
+        if name:
+            parts = [name]
+            if author:
+                parts.append(f"by {author}")
+            text = " ".join(parts)
+            if desc:
+                text = f"{text} - {desc}"
+        else:
+            text = os.path.basename(path)
+
+        cb = tk.Checkbutton(self.mods_container, text=text, variable=var, anchor='w', justify='left', wraplength=300)
         cb.bind('<Button-1>', lambda e, i=idx: self.select_mod(i))
         cb.pack(anchor='w', fill='x')
         self.mod_entries.append({'path': path, 'var': var, 'widget': cb})

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -183,10 +183,8 @@ def _apply_patch_to_file(target_path, section, data_lines, mod_name=None, author
         for j in range(anchor + 1, len(lines)):
             if _extract_key(lines[j].lstrip()) == key:
                 if mod_tag:
-                    original = lines[j]
-                    comment_original = f"{c_start}ORIGINAL: {original}{c_end}"
-                    lines[j:j+1] = [comment_original, mod_tag, new_line]
-                    j += 2
+                    lines[j:j+1] = [mod_tag, new_line]
+                    j += 1
                 else:
                     lines[j] = new_line
                 replaced = True


### PR DESCRIPTION
## Summary
- avoid cluttering patch output with original lines
- show mod name, author and description in the GUI when metadata is available

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688289c61f8083219bb829a9016e886f