### PR TITLE
Fix NameError during mod merge

### DIFF
--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -411,15 +411,16 @@ def apply_mods_to_temp(game, mods):
     # 4. Export to the game folder if configured
     config = load_config()
     game_paths = config.get("game_paths", {})
-    if selected_game == "fa2":
+    if game == "fa2":
         key = "Full Auto 2: Battlelines (PS3)"
     else:
         key = "Full Auto (Xbox 360)"
     game_root = game_paths.get(key)
     if game_root:
-        export_smallf_to_game(selected_game, mod_name, game_root)
+        export_smallf_to_game(game, mod_name, game_root)
     else:
         log("[WARN] Game path not configured; skipping export.")
 
     log("\n[Done] Workflow complete.")
+    output_smallf = os.path.join(FINISHED_DIR, mod_name, "smallf.dat")
     log(f"You can find your new smallf.dat here:\n  {output_smallf}")


### PR DESCRIPTION
## Summary
- fix usage of undefined variable `selected_game` in apply_mods_to_temp
- log export destination using computed path

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`
- *(fails: Permission denied running unpack_smallf_win.exe)*

------
https://chatgpt.com/codex/tasks/task_e_6882984fba5c83218ff8a7712e6d3c98