### PR TITLE
Add experimental comment toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Game directories and settings are stored in `fa_mod_manager_config.json`. The JS
         "Full Auto (Xbox 360)": "C:/Path/To/Full Auto",
         "Full Auto 2: Battlelines (PS3)": "C:/Path/To/Full Auto 2"
     },
-    "logging_enabled": false
+    "logging_enabled": false,
+    "comments_enabled": true
 }
 ```
 
-Use the **Settings** button in the GUI to select or update these paths and toggle logging. The backend saves them using `save_config()` and they are loaded on startup via `load_config()`.
+Use the **Settings** button in the GUI to select or update these paths, toggle logging, and enable/disable the experimental comment feature. The backend saves them using `save_config()` and they are loaded on startup via `load_config()`.
 
 ## Basic Workflow
 

--- a/fa_mod_manager_config.example.json
+++ b/fa_mod_manager_config.example.json
@@ -3,5 +3,6 @@
     "Full Auto (Xbox 360)": "",
     "Full Auto 2: Battlelines (PS3)": ""
   },
-  "logging_enabled": false
+  "logging_enabled": false,
+  "comments_enabled": true
 }

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -26,7 +26,9 @@ class FAModManager(TkinterDnD.Tk):
         self.game_paths = {game: "" for game in GAMES}
         self.game_paths.update(config.get("game_paths", {}))
         self.logging_enabled = config.get("logging_enabled", False)
+        self.comments_enabled = config.get("comments_enabled", True)
         backend.init_logger(self.logging_enabled)
+        backend.init_comments(self.comments_enabled)
 
         # Top: Game dropdown & settings
         top_frame = tk.Frame(self)
@@ -135,13 +137,18 @@ class FAModManager(TkinterDnD.Tk):
         log_var = tk.BooleanVar(value=self.logging_enabled)
         tk.Checkbutton(win, text="Enable logging", variable=log_var).grid(row=row, column=0, columnspan=3, sticky="w", pady=4, padx=5)
         row += 1
+        comment_var = tk.BooleanVar(value=self.comments_enabled)
+        tk.Checkbutton(win, text="Add mod comments (experimental)", variable=comment_var).grid(row=row, column=0, columnspan=3, sticky="w", pady=2, padx=5)
+        row += 1
 
         def save():
             for g, var in entries.items():
                 self.game_paths[g] = var.get()
             self.logging_enabled = log_var.get()
-            backend.save_config({"game_paths": self.game_paths, "logging_enabled": self.logging_enabled})
+            self.comments_enabled = comment_var.get()
+            backend.save_config({"game_paths": self.game_paths, "logging_enabled": self.logging_enabled, "comments_enabled": self.comments_enabled})
             backend.init_logger(self.logging_enabled)
+            backend.init_comments(self.comments_enabled)
             win.destroy()
 
         tk.Button(win, text="Save", command=save).grid(row=row, column=0, columnspan=3, pady=5)

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -23,6 +23,7 @@ LOG_FILE = os.path.join(BASE_DIR, "fa_mod_manager.log")
 logger = logging.getLogger("fa_mod_manager")
 logger.setLevel(logging.INFO)
 LOGGING_ENABLED = False
+COMMENTS_ENABLED = True
 
 
 # ----------- Config management -----------
@@ -38,7 +39,7 @@ def load_config():
         if os.path.isfile(example):
             shutil.copy2(example, CONFIG_FILE)
         else:
-            default = {"game_paths": {}, "logging_enabled": False}
+            default = {"game_paths": {}, "logging_enabled": False, "comments_enabled": True}
             with open(CONFIG_FILE, "w") as f:
                 json.dump(default, f)
     try:
@@ -49,9 +50,11 @@ def load_config():
 
     if "game_paths" not in data:
         # upgrade old format
-        data = {"game_paths": data, "logging_enabled": False}
+        data = {"game_paths": data, "logging_enabled": False, "comments_enabled": True}
     if "logging_enabled" not in data:
         data["logging_enabled"] = False
+    if "comments_enabled" not in data:
+        data["comments_enabled"] = True
     return data
 
 
@@ -68,6 +71,16 @@ def init_logger(enabled):
 
 def get_logging_enabled():
     return LOGGING_ENABLED
+
+
+def init_comments(enabled):
+    """Enable or disable summary comments."""
+    global COMMENTS_ENABLED
+    COMMENTS_ENABLED = enabled
+
+
+def get_comments_enabled():
+    return COMMENTS_ENABLED
 
 
 def log(msg):
@@ -215,7 +228,7 @@ def _apply_patch_to_file(target_path, section, data_lines, next_section=None):
 
 def _append_summary_comment(target_path, changed_lines, mod_name=None, author=None):
     """Append a summary comment listing changed lines for a mod."""
-    if not changed_lines:
+    if not COMMENTS_ENABLED or not changed_lines:
         return
     with open(target_path, "r", encoding="utf-8", errors="ignore") as f:
         lines = f.read().splitlines()


### PR DESCRIPTION
## Summary
- support disabling summary comments in backend
- persist setting in config
- add checkbox for comments in GUI settings
- document new setting

## Testing
- `python3 -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68829f97450883219126ced354549d17