### PR TITLE
Fix mod profile deletion

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -231,8 +231,14 @@ class FAModManager(TkinterDnD.Tk):
         selected = self.profile_list.curselection()
         if selected:
             name = self.profile_list.get(selected[0])
+            try:
+                backend.delete_profile(name)
+            except Exception as exc:
+                messagebox.showerror("Error", f"Failed to delete profile:\n{exc}")
+                return
             self.profile_list.delete(selected[0])
             self.profile_smallfs.pop(name, None)
+            self.update_profile_placeholder()
         else:
             messagebox.showwarning("Select a Profile", "No profile selected!")
 

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -386,6 +386,15 @@ def list_existing_profiles():
             names.append(name)
     return names
 
+
+def delete_profile(name):
+    """Remove a profile folder inside ``finished``."""
+    path = os.path.join(FINISHED_DIR, name)
+    if not os.path.isdir(path):
+        raise FileNotFoundError(f"Profile not found: {name}")
+    shutil.rmtree(path)
+    log(f"[OK] Deleted profile '{name}'")
+
 # ----------- Patch/merge logic placeholder -----------
 def apply_mods_to_temp(game, mods, merge_name=None):
     """Apply a sequence of mod files to the temporary unpacked directory.


### PR DESCRIPTION
## Summary
- remove profile directory in backend
- delete profile dir when using the GUI profile delete button

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6883527daaf08321a121329c1b1bf98f