### PR TITLE
Fix tool path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This project provides a proof of concept for managing and merging mods for **Ful
   - `bundled/tools/repack_smallf_win.exe`
 - Python 3 with Tkinter for the GUI (`mod_manager.py`).
 When packaged with PyInstaller the `bundled` directory is included inside the executable while
-`mod_profiles`, `smallf`, `exiso`, and `xbox_extract` remain next to the program so they can be modified by the user.
+`mod_profiles`, `smallf`, `exiso`, and `xbox_extract` remain next to the program so they can be modified by the user. If
+`bundled/tools` is missing the program falls back to `smallf/tools` for compatibility with older setups.
 
 ## Configuring Game Paths
 

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -19,7 +19,9 @@ MOD_PROFILES_DIR = os.path.join(APP_DIR, "mod_profiles")
 EXISO_DIR = os.path.join(APP_DIR, "exiso")
 XBOX_EXTRACT_DIR = os.path.join(APP_DIR, "xbox_extract")
 
-TOOLS_DIR = os.path.join(BUNDLED_DIR, "tools")
+BUNDLED_TOOLS_DIR = os.path.join(BUNDLED_DIR, "tools")
+LEGACY_TOOLS_DIR = os.path.join(SMALLF_DIR, "tools")
+TOOLS_DIR = BUNDLED_TOOLS_DIR if os.path.isdir(BUNDLED_TOOLS_DIR) else LEGACY_TOOLS_DIR
 BASE_FA_DIR = os.path.join(SMALLF_DIR, "fa")
 BASE_FA2_DIR = os.path.join(SMALLF_DIR, "fa2")
 


### PR DESCRIPTION
## Summary
- support new `bundled/tools` layout for unpack/repack tools
- document fallback to `smallf/tools`

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_688360be58bc8321be7f83cb22c1f624