### PR TITLE
Fix order of extract-xiso arguments

### DIFF
--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -422,7 +422,9 @@ def extract_xbox_iso(iso_path, dest=None):
         raise FileNotFoundError(f"ISO not found: {iso_path}")
 
     os.makedirs(dest, exist_ok=True)
-    cmd = [EXISO_EXE, iso_path, "-d", dest]
+    # extract-xiso expects the -d option before the ISO path, otherwise it
+    # interprets "-d" as a filename. Pass arguments in the correct order.
+    cmd = [EXISO_EXE, "-d", dest, iso_path]
     try:
         result = subprocess.run(
             cmd,


### PR DESCRIPTION
## Summary
- fix argument order when calling extract-xiso so `-d` works

## Testing
- `python3 -m py_compile mod_manager_backend.py mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6883822f53ec832184d9dff90d270118