### PR TITLE
Update ISO extraction path logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ in the profile list using the folder name.
 
 The `exiso` folder contains the `extract-xiso` tool used to unpack Xbox 360 ISOs.
 Select an ISO and extraction folder from the **Settings** menu and click
-**Extract ISO** to unpack the game. By default extracted files are placed in the
-`xbox_extract` directory next to the program.
+**Extract ISO** to unpack the game. The contents are placed inside a folder named
+after the ISO within the chosen directory. By default this directory is
+`xbox_extract` next to the program.

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -235,7 +235,7 @@ class FAModManager(TkinterDnD.Tk):
                 return
             dest = extract_var.get() or backend.XBOX_EXTRACT_DIR
             try:
-                backend.extract_xbox_iso(iso, dest)
+                dest = backend.extract_xbox_iso(iso, dest)
                 entries["Full Auto (Xbox 360)"].set(dest)
                 self.game_paths["Full Auto (Xbox 360)"] = dest
                 messagebox.showinfo("Extracted", f"ISO extracted to:\n{dest}")

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -410,16 +410,24 @@ def restore_original_smallf(game, game_root):
 def extract_xbox_iso(iso_path, dest=None):
     """Extract an Xbox 360 ISO using ``extract-xiso``.
 
-    The previous implementation simply called the ``extract-xiso`` binary and
-    surfaced a generic ``CalledProcessError`` when the command failed.  This made
-    it hard for users to diagnose issues such as missing files or permission
-    errors.  We now verify the ISO path and capture the tool's output so the
-    raised exception contains useful information.
+    The ISO's contents are placed inside a folder named after the ISO file
+    within ``dest``.  The previous implementation simply called the
+    ``extract-xiso`` binary and surfaced a generic ``CalledProcessError`` when
+    the command failed.  This made it hard for users to diagnose issues such as
+    missing files or permission errors.  We now verify the ISO path and capture
+    the tool's output so the raised exception contains useful information.
     """
     if dest is None:
         dest = XBOX_EXTRACT_DIR
     if not os.path.isfile(iso_path):
         raise FileNotFoundError(f"ISO not found: {iso_path}")
+
+    iso_name = os.path.splitext(os.path.basename(iso_path))[0]
+    # Always create a subfolder named after the ISO to avoid cluttering the
+    # chosen directory. If the provided path already ends with the ISO name,
+    # keep it as-is.
+    if os.path.basename(os.path.normpath(dest)).lower() != iso_name.lower():
+        dest = os.path.join(dest, iso_name)
 
     os.makedirs(dest, exist_ok=True)
     # extract-xiso expects the -d option before the ISO path, otherwise it


### PR DESCRIPTION
## Summary
- create subfolder named after ISO when extracting
- capture returned path from backend when extracting
- document the new extraction behavior

## Testing
- `python -m py_compile mod_manager.py mod_manager_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_688382feb33c8321a80bf27ec74d38e7