### PR TITLE
Fix case sensitivity for FA1 smallf

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -5,6 +5,14 @@ from tkinterdnd2 import TkinterDnD, DND_FILES
 
 import mod_manager_backend as backend
 
+
+def find_smallf_file(folder):
+    """Return path to smallf.dat in *folder* regardless of case."""
+    for name in os.listdir(folder):
+        if name.lower() == "smallf.dat":
+            return os.path.join(folder, name)
+    return None
+
 # --- Dummy data for demo purposes ---
 GAMES = ['Full Auto (Xbox 360)', 'Full Auto 2: Battlelines (PS3)']
 DEMO_PROFILES = []
@@ -370,8 +378,8 @@ class FAModManager(TkinterDnD.Tk):
         folder = filedialog.askdirectory(title='Select folder with smallf.dat', mustexist=True)
         if not folder:
             return
-        smallf_path = os.path.join(folder, 'smallf.dat')
-        if not os.path.isfile(smallf_path):
+        smallf_path = find_smallf_file(folder)
+        if not smallf_path:
             messagebox.showerror('Error', 'smallf.dat not found in selected folder.')
             return
         profile_name = os.path.basename(folder)

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -299,6 +299,18 @@ def _append_summary_comment(target_path, changed_lines, mod_name=None, author=No
 
 
 # ----------- Unpack and repack functions -----------
+
+def _normalize_smallf_dir(path):
+    """Ensure unpacked directory uses a lowercase 'smallf' folder."""
+    lower = os.path.join(path, "smallf")
+    if os.path.isdir(lower):
+        return lower
+    for name in os.listdir(path):
+        if name.lower() == "smallf":
+            os.rename(os.path.join(path, name), lower)
+            return lower
+    return lower
+
 def _ensure_base_unpacked(game):
     """Unpack the original smallf.dat once and cache the result."""
     exe = os.path.join(TOOLS_DIR, "unpack_smallf_win.exe")
@@ -316,6 +328,7 @@ def _ensure_base_unpacked(game):
         subprocess.check_call([exe, os.path.basename(dat_copy)], cwd=unpack_dir)
         os.remove(dat_copy)
         log(f"[OK] Cached base unpack to: {unpack_dir}")
+    _normalize_smallf_dir(unpack_dir)
     return unpack_dir
 
 
@@ -331,6 +344,7 @@ def unpack_smallf(game):
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
     shutil.copytree(unpack_dir, temp_dir)
+    _normalize_smallf_dir(temp_dir)
     log(f"[OK] Prepared temp folder at {temp_dir}")
     return temp_dir
 


### PR DESCRIPTION
## Summary
- normalize unpacked folder names so FA1 `smallF` becomes `smallf`
- detect `smallF.dat` when importing profiles

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6883856634688321b1d7e791aaed379a