### PR TITLE
Fix export path for Full Auto 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use the **Settings** button in the GUI to select or update these paths, toggle l
 3. **Repack** – `backend.repack_smallf(game, mod_name)` copies the unpacked files
    into `bundled/tools` and runs `repack_smallf_win.exe` without arguments. The
    resulting file is stored under `mod_profiles/<game>/<mod_name>/smallf.dat`.
-4. **Export** – `backend.export_smallf_to_game(game, mod_name, game_root)` copies the new file to `PS3_GAME/USRDIR/smallf.dat`, replacing the existing file. Use the **Revert to Original** button to restore the vanilla file.
+4. **Export** – `backend.export_smallf_to_game(game, mod_name, game_root)` copies the new file back to the game. On PS3 it is placed in `PS3_GAME/USRDIR/smallf.dat`, while the Xbox 360 version expects `smallF.dat` directly in the game root. Use the **Revert to Original** button to restore the vanilla file.
 
 This sequence is also demonstrated in the `__main__` section of `mod_manager_backend.py` and forms the foundation of the GUI.
 

--- a/mod_manager_backend.py
+++ b/mod_manager_backend.py
@@ -435,9 +435,15 @@ def export_smallf_to_game(game, mod_name, game_root):
     if not os.path.isfile(src):
         raise FileNotFoundError(f"Repacked file not found: {src}")
 
-    dest_dir = os.path.join(game_root, "PS3_GAME", "USRDIR")
+    if game == "fa2":
+        dest_dir = os.path.join(game_root, "PS3_GAME", "USRDIR")
+        os.makedirs(dest_dir, exist_ok=True)
+        filename = "smallf.dat"
+    else:
+        dest_dir = game_root
+        filename = "smallF.dat"
     os.makedirs(dest_dir, exist_ok=True)
-    dest = os.path.join(dest_dir, "smallf.dat")
+    dest = os.path.join(dest_dir, filename)
     shutil.copy2(src, dest)
     log(f"[OK] Exported modified smallf to: {dest}")
 
@@ -446,11 +452,14 @@ def restore_original_smallf(game, game_root):
     """Restore the original smallf.dat for the given game."""
     if game == "fa2":
         src = os.path.join(BASE_FA2_DIR, "smallf.dat")
+        dest_dir = os.path.join(game_root, "PS3_GAME", "USRDIR")
+        filename = "smallf.dat"
     else:
         src = os.path.join(BASE_FA_DIR, "smallF.dat")
-    dest_dir = os.path.join(game_root, "PS3_GAME", "USRDIR")
+        dest_dir = game_root
+        filename = "smallF.dat"
     os.makedirs(dest_dir, exist_ok=True)
-    dest = os.path.join(dest_dir, "smallf.dat")
+    dest = os.path.join(dest_dir, filename)
     shutil.copy2(src, dest)
     log(f"[OK] Restored original smallf to: {dest}")
 


### PR DESCRIPTION
## Summary
- update export/restore functions to place Xbox version `smallF.dat` in the game root
- clarify export path differences in README

## Testing
- `python3 -m py_compile mod_manager_backend.py mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6883931ed9d48321a0a79bd5cbe62069