### PR TITLE
Improve icon rescaling quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a proof of concept for managing and merging mods for **Ful
   - `bundled/tools/unpack_smallf_win.exe`
   - `bundled/tools/repack_smallf_win.exe`
 - Python 3 with Tkinter for the GUI (`mod_manager.py`).
+- [Pillow](https://python-pillow.org/) for image loading and scaling.
 When packaged with PyInstaller the `bundled` directory is included inside the executable while
 `mod_profiles`, `smallf`, `exiso`, and `xbox_extract` remain next to the program so they can be modified by the user. If
 `bundled/tools` is missing the program falls back to `smallf/tools` for compatibility with older setups.

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -1,6 +1,7 @@
 import os
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog, filedialog
+from PIL import Image, ImageTk
 from tkinterdnd2 import TkinterDnD, DND_FILES
 
 import mod_manager_backend as backend
@@ -45,14 +46,14 @@ class FAModManager(TkinterDnD.Tk):
         icon_dir = os.path.join(os.path.dirname(__file__), "bundled", "icons")
 
         def load_icon(name):
-            img = tk.PhotoImage(file=os.path.join(icon_dir, name))
-            # Many icons in the repo are quite large; shrink them so the UI
-            # isn't overwhelmed when they are placed in Labels.
+            path = os.path.join(icon_dir, name)
+            img = Image.open(path)
             max_size = 64
-            factor = max(img.width() // max_size, img.height() // max_size, 1)
-            if factor > 1:
-                img = img.subsample(factor, factor)
-            return img
+            ratio = max(img.width / max_size, img.height / max_size, 1)
+            if ratio > 1:
+                new_size = (int(img.width / ratio), int(img.height / ratio))
+                img = img.resize(new_size, Image.LANCZOS)
+            return ImageTk.PhotoImage(img)
 
         self.icon_ps3 = load_icon("ps3.png")
         self.icon_xbox = load_icon("xbox360.png")


### PR DESCRIPTION
## Summary
- use Pillow for smoother icon resizing
- document Pillow requirement in README

## Testing
- `python3 -m py_compile mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6883950df49083218c2f612b60b4e5fa