### PR TITLE
Add line-based mod edit support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,9 +86,10 @@ Mods are defined as simple `.txt` files:
 
 - **Metadata:** `name`, `author`, `description`
 - **Patch instructions:** Each `[FILE ...]` block targets a specific file (e.g., `.psc` or `.txt`), a section (anchor), and supplies edit lines.
-- **Insertion Syntax:**  
-  - `;` prefix: replace existing line or append if not found  
+- **Insertion Syntax:**
+  - `;` prefix: replace existing line or append if not found
   - `.;` prefix: insert immediately after section header
+  - `L<number>;text` replace the specified line (1-indexed) before any section processing
 
 **Example Mod:**
 ```

--- a/mod_manager.py
+++ b/mod_manager.py
@@ -545,8 +545,8 @@ class FAModManager(TkinterDnD.Tk):
         idx = len(self.mod_entries)
         var = tk.BooleanVar(value=True)
         try:
-            meta, patches = backend._parse_mod_file(path)
-            if not patches:
+            meta, patches, line_edits = backend._parse_mod_file(path)
+            if not patches and not line_edits:
                 messagebox.showerror(
                     "Invalid Mod File",
                     f"{os.path.basename(path)} does not contain mod data.",


### PR DESCRIPTION
## Summary
- parse new `L<number>;text` syntax for absolute line edits
- process all line edits before section patches in `apply_mods_to_temp`
- expose line edit handling in GUI loader
- document new syntax in `AGENTS.md`

## Testing
- `python -m py_compile mod_manager_backend.py mod_manager.py config_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68890cb28ccc8321bc259600e8bc0a8a